### PR TITLE
bug: Fixed nextPageToken not changing bug.

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "tabWidth": 4,
+  "singleQuote": true
+}

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -20,7 +20,7 @@ const _getPlaylistItems = async (
     const MAX_RESULTS = 50;
     const URL = `${BASE_URL}/playlistItems?part=${parts.join(
         '%2C'
-    )}&playlistId=${playlistId}&maxResults=${MAX_RESULTS}&key=${API_KEY}&nextPageToken=${nextPageToken}`;
+    )}&playlistId=${playlistId}&maxResults=${MAX_RESULTS}&key=${API_KEY}&pageToken=${nextPageToken}`;
 
     const { data } = await axios.get(URL);
 
@@ -60,6 +60,7 @@ const getPlaylistById = async (playlistId) => {
             thumbnails: playlistThumbnails,
             channelTitle,
             publishedAt: playlistPublishedAt,
+            // eslint-disable-next-line no-unsafe-optional-chaining
         } = playlist?.items[0]?.snippet;
 
         const playlistItems = await _getPlaylistItems(playlistId);


### PR DESCRIPTION
The API URL had a mistake inside it. Insead of pageToken there was extPageToken on the URL in _getPlaylistItems()method. Besides that a new file added named .prettierrc for formating.

Issue #7